### PR TITLE
Updated exploitdb repo, which breaks installs

### DIFF
--- a/files/apps_repo/demon_apps.json
+++ b/files/apps_repo/demon_apps.json
@@ -502,7 +502,7 @@
         "demon_version": "4.0",
         "installed": "False",
         "category": "exploit",
-        "project_uri": "https://github.com/offensive-security/exploitdb",
+        "project_uri": "https://gitlab.com/exploit-database/exploitdb",
         "about": "Archive of public exploits and corresponding vulnerable software",
         "install_path": "",
         "author": "Offensive Security",


### PR DESCRIPTION
Exploit DB moved to gitlab last week.  Running `sudo python3 summon.py install all` with the github url for exploit DB caused an exception for me on app install, and it wouldn't install apps in the list after it.  Updating demon_apps.json with the new location fixed it for me, hence pull request.  Tested via re-running above command and having it run to completion.